### PR TITLE
feat(agents): forward MCP server configs to Copilot SDK sessions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.1.0
+      '@github/copilot-sdk':
+        specifier: 0.1.32
+        version: 0.1.32
       '@homebridge/ciao':
         specifier: ^1.3.5
         version: 1.3.5
@@ -1349,6 +1352,50 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@github/copilot-darwin-arm64@1.0.11':
+    resolution: {integrity: sha512-wdKimjtbsVeXqMqQSnGpGBPFEYHljxXNuWeH8EIJTNRgFpAsimcivsFgql3Twq4YOp0AxfsH36icG4IEen30mA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.11':
+    resolution: {integrity: sha512-VeuPv8rzBVGBB8uDwMEhcHBpldoKaq26yZ5YQm+G9Ka5QIF+1DMah8ZNRMVsTeNKkb1ji9G8vcuCsaPbnG3fKg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.11':
+    resolution: {integrity: sha512-/d8p6RlFYKj1Va2hekFIcYNMHWagcEkaxgcllUNXSyQLnmEtXUkaWtz62VKGWE+n/UMkEwCB6vI2xEwPTlUNBQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.11':
+    resolution: {integrity: sha512-UujTRO3xkPFC1CybchBbCnaTEAG6JrH0etIst07JvfekMWgvRxbiCHQPpDPSzBCPiBcGu0gba0/IT+vUCORuIw==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-sdk@0.1.32':
+    resolution: {integrity: sha512-mPWM0fw1Gqc/SW8nl45K8abrFH+92fO7y6tRtRl5imjS5hGapLf/dkX5WDrgPtlsflD0c41lFXVUri5NVJwtoA==}
+    engines: {node: '>=20.0.0'}
+
+  '@github/copilot-win32-arm64@1.0.11':
+    resolution: {integrity: sha512-EOW8HUM+EmnHEZEa+iUMl4pP1+2eZUk2XCbynYiMehwX9sidc4BxEHp2RuxADSzFPTieQEWzgjQmHWrtet8pQg==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.11':
+    resolution: {integrity: sha512-fKGkSNamzs3h9AbmswNvPYJBORCb2Y8CbusijU3C7fT3ohvqnHJwKo5iHhJXLOKZNOpFZgq9YKha410u9sIs6Q==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.11':
+    resolution: {integrity: sha512-cptVopko/tNKEXyBP174yBjHQBEwg6CqaKN2S0M3J+5LEB8u31bLL75ioOPd+5vubqBrA0liyTdcHeZ8UTRbmg==}
+    hasBin: true
 
   '@google/genai@1.42.0':
     resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
@@ -6697,6 +6744,10 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -7849,6 +7900,39 @@ snapshots:
   '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
     optionalDependencies:
       '@noble/hashes': 2.0.1
+
+  '@github/copilot-darwin-arm64@1.0.11':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.11':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.11':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.11':
+    optional: true
+
+  '@github/copilot-sdk@0.1.32':
+    dependencies:
+      '@github/copilot': 1.0.11
+      vscode-jsonrpc: 8.2.1
+      zod: 4.3.6
+
+  '@github/copilot-win32-arm64@1.0.11':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.11':
+    optional: true
+
+  '@github/copilot@1.0.11':
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.11
+      '@github/copilot-darwin-x64': 1.0.11
+      '@github/copilot-linux-arm64': 1.0.11
+      '@github/copilot-linux-x64': 1.0.11
+      '@github/copilot-win32-arm64': 1.0.11
+      '@github/copilot-win32-x64': 1.0.11
 
   '@google/genai@1.42.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
     dependencies:
@@ -13578,6 +13662,8 @@ snapshots:
       - msw
 
   void-elements@3.1.0: {}
+
+  vscode-jsonrpc@8.2.1: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/agents/copilot-runner.test.ts
+++ b/src/agents/copilot-runner.test.ts
@@ -9,6 +9,13 @@ vi.mock("./copilot-sdk.js", () => ({
   runCopilotAgent: (...args: unknown[]) => runCopilotAgentMock(...args),
 }));
 
+// Mock bundle-mcp to control MCP server loading in tests
+const loadEnabledBundleMcpConfigMock = vi.fn();
+vi.mock("../plugins/bundle-mcp.js", () => ({
+  loadEnabledBundleMcpConfig: (...args: unknown[]) => loadEnabledBundleMcpConfigMock(...args),
+  extractMcpServerMap: vi.fn(),
+}));
+
 // Stub out bootstrap/docs resolution to avoid filesystem side effects
 vi.mock("./bootstrap-files.js", () => ({
   resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
@@ -25,6 +32,12 @@ describe("runCopilotCliAgent", () => {
   beforeEach(() => {
     checkCopilotAvailableMock.mockReset();
     runCopilotAgentMock.mockReset();
+    loadEnabledBundleMcpConfigMock.mockReset();
+    // Default: no MCP servers
+    loadEnabledBundleMcpConfigMock.mockReturnValue({
+      config: { mcpServers: {} },
+      diagnostics: [],
+    });
   });
 
   it("throws FailoverError when copilot is not available", async () => {
@@ -173,5 +186,79 @@ describe("runCopilotCliAgent", () => {
     // When model is "default", SDK receives undefined so it uses its own default
     expect(sdkArgs.model).toBeUndefined();
     expect(result.meta?.agentMeta?.model).toBe("default");
+  });
+
+  it("passes MCP servers to SDK when bundle-mcp config has servers", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "MCP available",
+      sessionId: "sid-mcp",
+    });
+    loadEnabledBundleMcpConfigMock.mockReturnValue({
+      config: {
+        mcpServers: {
+          "my-server": {
+            command: "node",
+            args: ["server.js"],
+            env: { API_KEY: "secret" },
+            cwd: "/tmp/plugins/my-server",
+            tools: ["search", "read"],
+          },
+          "remote-server": {
+            type: "http",
+            url: "https://example.com/mcp",
+            headers: { Authorization: "Bearer abc" },
+            tools: ["query"],
+          },
+        },
+      },
+      diagnostics: [],
+    });
+
+    await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "use mcp",
+      timeoutMs: 5_000,
+      runId: "run-mcp",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.mcpServers).toBeDefined();
+    expect(Object.keys(sdkArgs.mcpServers)).toEqual(["my-server", "remote-server"]);
+    expect(sdkArgs.mcpServers["my-server"]).toEqual({
+      command: "node",
+      args: ["server.js"],
+      env: { API_KEY: "secret" },
+      cwd: "/tmp/plugins/my-server",
+      tools: ["search", "read"],
+    });
+    expect(sdkArgs.mcpServers["remote-server"]).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer abc" },
+      tools: ["query"],
+    });
+  });
+
+  it("does not pass mcpServers when no MCP servers are configured", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "no mcp",
+      sessionId: "sid-nomcp",
+    });
+
+    await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      timeoutMs: 5_000,
+      runId: "run-nomcp",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.mcpServers).toBeUndefined();
   });
 });

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -2,11 +2,13 @@ import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { loadEnabledBundleMcpConfig, type BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
 import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
+import type { CopilotMcpServerConfig } from "./copilot-sdk.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-helpers.js";
@@ -114,6 +116,12 @@ export async function runCopilotCliAgent(params: {
   try {
     log.info(`copilot-cli exec: model=${modelId} promptChars=${params.prompt.length}`);
 
+    // Load MCP server configs from OpenClaw's bundle-mcp infrastructure
+    const mcpServers = loadMcpServersForSdk({
+      workspaceDir: resolvedWorkspace,
+      config: params.config,
+    });
+
     const result = await runCopilotAgent({
       prompt: params.prompt,
       model: modelId === "default" ? undefined : modelId,
@@ -121,6 +129,7 @@ export async function runCopilotCliAgent(params: {
       systemPrompt,
       timeoutMs: params.timeoutMs,
       sessionId: params.cliSessionId,
+      mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,
     });
 
     const text = result.text?.trim();
@@ -154,4 +163,69 @@ export async function runCopilotCliAgent(params: {
     }
     throw err;
   }
+}
+
+/**
+ * Convert OpenClaw's BundleMcpServerConfig to Copilot SDK's MCPServerConfig format.
+ */
+function convertBundleMcpServer(server: BundleMcpServerConfig): CopilotMcpServerConfig {
+  const type = typeof server.type === "string" ? server.type : undefined;
+  const isRemote = type === "http" || type === "sse";
+
+  if (isRemote) {
+    return {
+      type: type,
+      url: typeof server.url === "string" ? server.url : "",
+      headers:
+        server.headers && typeof server.headers === "object"
+          ? (server.headers as Record<string, string>)
+          : undefined,
+      tools: Array.isArray(server.tools) ? (server.tools as string[]) : [],
+    };
+  }
+
+  return {
+    type: (type as "local" | "stdio" | undefined) ?? undefined,
+    command: typeof server.command === "string" ? server.command : "",
+    args: Array.isArray(server.args) ? (server.args as string[]) : [],
+    env:
+      server.env && typeof server.env === "object"
+        ? (server.env as Record<string, string>)
+        : undefined,
+    cwd: typeof server.cwd === "string" ? server.cwd : undefined,
+    tools: Array.isArray(server.tools) ? (server.tools as string[]) : [],
+  };
+}
+
+/**
+ * Load enabled MCP servers from OpenClaw's plugin config and convert to SDK format.
+ */
+function loadMcpServersForSdk(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+}): Record<string, CopilotMcpServerConfig> {
+  const bundleResult = loadEnabledBundleMcpConfig({
+    workspaceDir: params.workspaceDir,
+    cfg: params.config,
+  });
+
+  for (const diagnostic of bundleResult.diagnostics) {
+    log.warn(`bundle MCP skipped for ${diagnostic.pluginId}: ${diagnostic.message}`);
+  }
+
+  const servers = bundleResult.config.mcpServers;
+  if (Object.keys(servers).length === 0) {
+    return {};
+  }
+
+  const result: Record<string, CopilotMcpServerConfig> = {};
+  for (const [name, server] of Object.entries(servers)) {
+    result[name] = convertBundleMcpServer(server);
+  }
+
+  log.info(`loaded ${Object.keys(result).length} MCP server(s) for Copilot SDK`, {
+    servers: Object.keys(result),
+  });
+
+  return result;
 }

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -199,6 +199,67 @@ describe("copilot-sdk", () => {
         content: "You are a helpful assistant.",
       });
     });
+
+    it("passes mcpServers to session config when provided", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "MCP ready." },
+      });
+
+      const mcpServers = {
+        "my-server": {
+          command: "node",
+          args: ["server.js"],
+          env: { FOO: "bar" },
+          tools: ["tool1", "tool2"],
+        },
+        "remote-server": {
+          type: "http" as const,
+          url: "https://example.com/mcp",
+          tools: ["tool3"],
+        },
+      };
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "use tools",
+        mcpServers,
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.mcpServers).toEqual(mcpServers);
+    });
+
+    it("does not set mcpServers when empty", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "No MCP." },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "hi",
+        mcpServers: {},
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.mcpServers).toBeUndefined();
+    });
+
+    it("does not set mcpServers when undefined", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "No MCP." },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "hi",
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.mcpServers).toBeUndefined();
+    });
   });
 
   describe("listCopilotModels", () => {

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -2,6 +2,7 @@ import type {
   CopilotClient,
   CopilotClientOptions,
   CopilotSession,
+  MCPServerConfig,
   ModelInfo,
   SessionConfig,
 } from "@github/copilot-sdk";
@@ -109,6 +110,8 @@ export async function listCopilotModels(options?: { cwd?: string }): Promise<Mod
   }
 }
 
+export type { MCPServerConfig as CopilotMcpServerConfig };
+
 export type CopilotAgentRunOptions = {
   prompt: string;
   model?: string;
@@ -116,6 +119,7 @@ export type CopilotAgentRunOptions = {
   systemPrompt?: string;
   timeoutMs?: number;
   sessionId?: string;
+  mcpServers?: Record<string, MCPServerConfig>;
 };
 
 export type CopilotAgentRunResult = {
@@ -156,6 +160,14 @@ export async function runCopilotAgent(
         mode: "append",
         content: options.systemPrompt,
       };
+    }
+
+    if (options.mcpServers && Object.keys(options.mcpServers).length > 0) {
+      sessionConfig.mcpServers = options.mcpServers;
+      log.info("configured MCP servers for session", {
+        count: Object.keys(options.mcpServers).length,
+        servers: Object.keys(options.mcpServers),
+      });
     }
 
     if (options.sessionId) {


### PR DESCRIPTION
Loads MCP servers from OpenClaw's `loadEnabledBundleMcpConfig()` and converts to SDK format (local/stdio vs http/sse). Passes directly to `sessionConfig.mcpServers` instead of `--mcp-config` CLI flag. Part of #4