### PR TITLE
feat(agents): surface Copilot SDK streaming events for observability

### DIFF
--- a/src/agents/copilot-event-mapper.test.ts
+++ b/src/agents/copilot-event-mapper.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCopilotEventLogger, extractUsageFromEvents } from "./copilot-event-mapper.js";
+
+describe("copilot-event-mapper", () => {
+  describe("createCopilotEventLogger", () => {
+    it("logs tool.execution_start events", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "tool.execution_start", toolName: "read_file" } as unknown);
+      expect(log).toHaveBeenCalledWith("copilot tool execution started", { tool: "read_file" });
+    });
+
+    it("logs tool.execution_complete events", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "tool.execution_complete", toolName: "read_file", success: true } as unknown);
+      expect(log).toHaveBeenCalledWith("copilot tool execution complete", {
+        tool: "read_file",
+        success: true,
+      });
+    });
+
+    it("logs session.usage_info events", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({
+        type: "session.usage_info",
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      } as unknown);
+      expect(log).toHaveBeenCalledWith("copilot usage info", {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+      });
+    });
+
+    it("logs assistant.reasoning without content", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "assistant.reasoning", content: "secret reasoning" } as unknown);
+      expect(log).toHaveBeenCalledWith("copilot reasoning in progress");
+    });
+
+    it("logs session compaction events", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "session.compaction_start" } as unknown);
+      handler({ type: "session.compaction_complete" } as unknown);
+      expect(log).toHaveBeenCalledTimes(2);
+      expect(log).toHaveBeenCalledWith("copilot session compaction started");
+      expect(log).toHaveBeenCalledWith("copilot session compaction complete");
+    });
+
+    it("logs subagent lifecycle events", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "subagent.started", subagentId: "sa-1", name: "coder" } as unknown);
+      handler({ type: "subagent.completed", subagentId: "sa-1", name: "coder" } as unknown);
+      handler({
+        type: "subagent.failed",
+        subagentId: "sa-2",
+        name: "reviewer",
+        error: "timeout",
+      } as unknown);
+      expect(log).toHaveBeenCalledTimes(3);
+      expect(log).toHaveBeenCalledWith("copilot subagent started", {
+        subagentId: "sa-1",
+        name: "coder",
+      });
+      expect(log).toHaveBeenCalledWith("copilot subagent completed", {
+        subagentId: "sa-1",
+        name: "coder",
+      });
+      expect(log).toHaveBeenCalledWith("copilot subagent failed", {
+        subagentId: "sa-2",
+        name: "reviewer",
+        error: "timeout",
+      });
+    });
+
+    it("ignores events without a type", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({} as unknown);
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    it("ignores unhandled event types", () => {
+      const log = vi.fn();
+      const handler = createCopilotEventLogger(log);
+      handler({ type: "assistant.message" } as unknown);
+      expect(log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("extractUsageFromEvents", () => {
+    it("returns undefined when no usage events", () => {
+      const result = extractUsageFromEvents([{ type: "tool.execution_start" } as unknown]);
+      expect(result).toBeUndefined();
+    });
+
+    it("extracts usage from a single event", () => {
+      const result = extractUsageFromEvents([
+        {
+          type: "session.usage_info",
+          promptTokens: 100,
+          completionTokens: 50,
+          totalTokens: 150,
+        } as unknown,
+      ]);
+      expect(result).toEqual({ promptTokens: 100, completionTokens: 50, totalTokens: 150 });
+    });
+
+    it("aggregates usage across multiple events", () => {
+      const result = extractUsageFromEvents([
+        {
+          type: "session.usage_info",
+          promptTokens: 100,
+          completionTokens: 50,
+          totalTokens: 150,
+        } as unknown,
+        { type: "tool.execution_start" } as unknown,
+        {
+          type: "session.usage_info",
+          promptTokens: 200,
+          completionTokens: 80,
+          totalTokens: 280,
+        } as unknown,
+      ]);
+      expect(result).toEqual({ promptTokens: 300, completionTokens: 130, totalTokens: 430 });
+    });
+
+    it("handles missing numeric fields as zero", () => {
+      const result = extractUsageFromEvents([
+        { type: "session.usage_info", promptTokens: 100 } as unknown,
+      ]);
+      expect(result).toEqual({ promptTokens: 100, completionTokens: 0, totalTokens: 0 });
+    });
+
+    it("returns undefined for empty array", () => {
+      expect(extractUsageFromEvents([])).toBeUndefined();
+    });
+  });
+});

--- a/src/agents/copilot-event-mapper.ts
+++ b/src/agents/copilot-event-mapper.ts
@@ -1,0 +1,87 @@
+import type { SessionEvent } from "@github/copilot-sdk";
+
+type LogFn = (message: string, data?: Record<string, unknown>) => void;
+
+/**
+ * Creates an event handler that logs interesting Copilot SDK session events.
+ * Returns the handler function to pass to `session.on(handler)`.
+ */
+export function createCopilotEventLogger(log: LogFn): (event: SessionEvent) => void {
+  return (event: SessionEvent) => {
+    const e = event as Record<string, unknown>;
+    const type = e.type as string | undefined;
+    if (!type) {
+      return;
+    }
+
+    switch (type) {
+      case "tool.execution_start":
+        log("copilot tool execution started", { tool: e.toolName ?? e.name });
+        break;
+      case "tool.execution_complete":
+        log("copilot tool execution complete", {
+          tool: e.toolName ?? e.name,
+          success: e.success ?? !e.error,
+        });
+        break;
+      case "session.usage_info":
+        log("copilot usage info", {
+          promptTokens: e.promptTokens,
+          completionTokens: e.completionTokens,
+          totalTokens: e.totalTokens,
+        });
+        break;
+      case "assistant.reasoning":
+        log("copilot reasoning in progress");
+        break;
+      case "session.compaction_start":
+        log("copilot session compaction started");
+        break;
+      case "session.compaction_complete":
+        log("copilot session compaction complete");
+        break;
+      case "subagent.started":
+        log("copilot subagent started", { subagentId: e.subagentId, name: e.name });
+        break;
+      case "subagent.completed":
+        log("copilot subagent completed", { subagentId: e.subagentId, name: e.name });
+        break;
+      case "subagent.failed":
+        log("copilot subagent failed", {
+          subagentId: e.subagentId,
+          name: e.name,
+          error: e.error,
+        });
+        break;
+    }
+  };
+}
+
+export type CopilotUsageInfo = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+};
+
+/**
+ * Extract aggregated usage info from a list of collected session events.
+ * Sums all `session.usage_info` events for cost tracking.
+ */
+export function extractUsageFromEvents(events: SessionEvent[]): CopilotUsageInfo | undefined {
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let totalTokens = 0;
+  let found = false;
+
+  for (const event of events) {
+    const e = event as Record<string, unknown>;
+    if (e.type === "session.usage_info") {
+      found = true;
+      promptTokens += (e.promptTokens as number) || 0;
+      completionTokens += (e.completionTokens as number) || 0;
+      totalTokens += (e.totalTokens as number) || 0;
+    }
+  }
+
+  return found ? { promptTokens, completionTokens, totalTokens } : undefined;
+}

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -6,6 +6,7 @@ import { resolveSessionAgentIds } from "./agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
+import { createCopilotEventLogger, extractUsageFromEvents } from "./copilot-event-mapper.js";
 import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
@@ -114,6 +115,14 @@ export async function runCopilotCliAgent(params: {
   try {
     log.info(`copilot-cli exec: model=${modelId} promptChars=${params.prompt.length}`);
 
+    // Collect events for usage extraction
+    const collectedEvents: import("@github/copilot-sdk").SessionEvent[] = [];
+    const eventLogger = createCopilotEventLogger((msg, data) => log.info(msg, data));
+    const onEvent = (event: import("@github/copilot-sdk").SessionEvent) => {
+      collectedEvents.push(event);
+      eventLogger(event);
+    };
+
     const result = await runCopilotAgent({
       prompt: params.prompt,
       model: modelId === "default" ? undefined : modelId,
@@ -121,10 +130,12 @@ export async function runCopilotCliAgent(params: {
       systemPrompt,
       timeoutMs: params.timeoutMs,
       sessionId: params.cliSessionId,
+      onEvent,
     });
 
     const text = result.text?.trim();
     const payloads = text ? [{ text }] : undefined;
+    const usage = extractUsageFromEvents(collectedEvents);
 
     return {
       payloads,
@@ -134,6 +145,15 @@ export async function runCopilotCliAgent(params: {
           sessionId: result.sessionId ?? params.sessionId ?? "",
           provider: "copilot-cli",
           model: modelId,
+          ...(usage
+            ? {
+                usage: {
+                  input: usage.promptTokens,
+                  output: usage.completionTokens,
+                  total: usage.totalTokens,
+                },
+              }
+            : {}),
         },
       },
     };

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -4,6 +4,7 @@ import type {
   CopilotSession,
   ModelInfo,
   SessionConfig,
+  SessionEvent,
 } from "@github/copilot-sdk";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
@@ -116,6 +117,8 @@ export type CopilotAgentRunOptions = {
   systemPrompt?: string;
   timeoutMs?: number;
   sessionId?: string;
+  /** Optional callback to receive all raw session events for observability. */
+  onEvent?: (event: SessionEvent) => void;
 };
 
 export type CopilotAgentRunResult = {
@@ -165,6 +168,12 @@ export async function runCopilotAgent(
     }
 
     const timeoutMs = options.timeoutMs ?? 120_000;
+
+    // Subscribe to session events for observability before sending
+    if (options.onEvent) {
+      session.on(options.onEvent);
+    }
+
     const response = await session.sendAndWait({ prompt: options.prompt }, timeoutMs);
 
     const text = response?.data?.content ?? "";


### PR DESCRIPTION
New `copilot-event-mapper.ts` with event logger + usage extraction. Pipes all SDK session events (tool exec, reasoning, compaction, subagents) through `onEvent` callback. Aggregates token usage from `session.usage_info` events. 12 tests. Part of #4