### PR TITLE
feat(agents): wire Copilot SDK user input handler for agent questions

### DIFF
--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -7,6 +7,7 @@ import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-fi
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
 import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
+import { createTimeoutUserInputHandler } from "./copilot-user-input.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-helpers.js";
@@ -114,6 +115,17 @@ export async function runCopilotCliAgent(params: {
   try {
     log.info(`copilot-cli exec: model=${modelId} promptChars=${params.prompt.length}`);
 
+    // Placeholder user input handler — auto-responds with a default message.
+    // The real handler will be wired to OpenClaw's messaging layer in a future PR.
+    // Having it enabled means the SDK exposes `ask_user` to the agent.
+    const onUserInput = createTimeoutUserInputHandler({
+      handler: async () => ({
+        answer: "User interaction not available in this session",
+        wasFreeform: true,
+      }),
+      timeoutMs: 5_000,
+    });
+
     const result = await runCopilotAgent({
       prompt: params.prompt,
       model: modelId === "default" ? undefined : modelId,
@@ -121,6 +133,7 @@ export async function runCopilotCliAgent(params: {
       systemPrompt,
       timeoutMs: params.timeoutMs,
       sessionId: params.cliSessionId,
+      onUserInput,
     });
 
     const text = result.text?.trim();

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -199,6 +199,74 @@ describe("copilot-sdk", () => {
         content: "You are a helpful assistant.",
       });
     });
+
+    it("passes onUserInputRequest to session config when onUserInput is provided", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Asked!" },
+      });
+
+      const userInputHandler = vi.fn().mockResolvedValue({
+        answer: "Yes",
+        wasFreeform: false,
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "ask me something",
+        timeoutMs: 5_000,
+        onUserInput: userInputHandler,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.onUserInputRequest).toBeDefined();
+      expect(typeof sessionConfig.onUserInputRequest).toBe("function");
+    });
+
+    it("does not set onUserInputRequest when onUserInput is not provided", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "No handler." },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "no user input",
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.onUserInputRequest).toBeUndefined();
+    });
+
+    it("wraps onUserInput and forwards request to the handler", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Done" },
+      });
+
+      const userInputHandler = vi.fn().mockResolvedValue({
+        answer: "Option A",
+        wasFreeform: false,
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "choose",
+        timeoutMs: 5_000,
+        onUserInput: userInputHandler,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      // Simulate the SDK calling the handler
+      const result = await sessionConfig.onUserInputRequest(
+        { question: "Pick one", choices: ["A", "B"], allowFreeform: true },
+        {},
+      );
+      expect(userInputHandler).toHaveBeenCalledWith({
+        question: "Pick one",
+        choices: ["A", "B"],
+        allowFreeform: true,
+      });
+      expect(result).toEqual({ answer: "Option A", wasFreeform: false });
+    });
   });
 
   describe("listCopilotModels", () => {

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -7,6 +7,17 @@ import type {
 } from "@github/copilot-sdk";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
+/**
+ * SDK user-input types — defined locally until `@github/copilot-sdk` exports them.
+ * These mirror the SDK's internal `UserInputRequest`, `UserInputResponse`, and `UserInputHandler`.
+ */
+type UserInputRequest = { question: string; choices?: string[]; allowFreeform?: boolean };
+type UserInputResponse = { answer: string; wasFreeform: boolean };
+type UserInputHandler = (
+  request: UserInputRequest,
+  invocation: unknown,
+) => Promise<UserInputResponse>;
+
 const log = createSubsystemLogger("agents/copilot-sdk");
 
 /**
@@ -116,6 +127,11 @@ export type CopilotAgentRunOptions = {
   systemPrompt?: string;
   timeoutMs?: number;
   sessionId?: string;
+  onUserInput?: (request: {
+    question: string;
+    choices?: string[];
+    allowFreeform?: boolean;
+  }) => Promise<{ answer: string; wasFreeform: boolean }>;
 };
 
 export type CopilotAgentRunResult = {
@@ -150,6 +166,24 @@ export async function runCopilotAgent(
         feedback: "Tool use is not permitted in this session.",
       }),
     };
+
+    if (options.onUserInput) {
+      const userHandler = options.onUserInput;
+      const wrappedHandler: UserInputHandler = async (request: UserInputRequest, _invocation) => {
+        log.info("copilot agent requesting user input", {
+          questionLength: request.question.length,
+          choiceCount: request.choices?.length ?? 0,
+          allowFreeform: request.allowFreeform ?? false,
+        });
+        const result = await userHandler({
+          question: request.question,
+          choices: request.choices,
+          allowFreeform: request.allowFreeform,
+        });
+        return result as UserInputResponse;
+      };
+      sessionConfig.onUserInputRequest = wrappedHandler;
+    }
 
     if (options.systemPrompt) {
       sessionConfig.systemMessage = {

--- a/src/agents/copilot-user-input.test.ts
+++ b/src/agents/copilot-user-input.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTimeoutUserInputHandler } from "./copilot-user-input.js";
+import type { UserInputRequest, UserInputResponse } from "./copilot-user-input.js";
+
+describe("copilot-user-input", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("createTimeoutUserInputHandler", () => {
+    it("forwards request to inner handler and returns its result", async () => {
+      const inner = vi
+        .fn<(req: UserInputRequest) => Promise<UserInputResponse>>()
+        .mockResolvedValue({
+          answer: "Yes",
+          wasFreeform: false,
+        });
+
+      const handler = createTimeoutUserInputHandler({ handler: inner });
+      const resultPromise = handler({ question: "Continue?", choices: ["Yes", "No"] });
+
+      // No timeout needed — inner resolves immediately
+      const result = await resultPromise;
+      expect(result).toEqual({ answer: "Yes", wasFreeform: false });
+      expect(inner).toHaveBeenCalledWith({ question: "Continue?", choices: ["Yes", "No"] });
+    });
+
+    it("returns default answer on timeout", async () => {
+      const inner = vi
+        .fn<(req: UserInputRequest) => Promise<UserInputResponse>>()
+        .mockImplementation(
+          () => new Promise(() => {}), // never resolves
+        );
+
+      const handler = createTimeoutUserInputHandler({
+        handler: inner,
+        timeoutMs: 5_000,
+      });
+      const resultPromise = handler({ question: "Are you there?" });
+
+      vi.advanceTimersByTime(5_000);
+      const result = await resultPromise;
+      expect(result).toEqual({ answer: "No response", wasFreeform: true });
+    });
+
+    it("uses custom defaultAnswer on timeout", async () => {
+      const inner = vi
+        .fn<(req: UserInputRequest) => Promise<UserInputResponse>>()
+        .mockImplementation(() => new Promise(() => {}));
+
+      const handler = createTimeoutUserInputHandler({
+        handler: inner,
+        timeoutMs: 1_000,
+        defaultAnswer: "Skipped by user",
+      });
+      const resultPromise = handler({ question: "Pick one" });
+
+      vi.advanceTimersByTime(1_000);
+      const result = await resultPromise;
+      expect(result).toEqual({ answer: "Skipped by user", wasFreeform: true });
+    });
+
+    it("returns inner result when it resolves before timeout", async () => {
+      const inner = vi
+        .fn<(req: UserInputRequest) => Promise<UserInputResponse>>()
+        .mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(() => resolve({ answer: "Quick!", wasFreeform: true }), 100);
+            }),
+        );
+
+      const handler = createTimeoutUserInputHandler({
+        handler: inner,
+        timeoutMs: 5_000,
+      });
+      const resultPromise = handler({ question: "Fast?" });
+
+      vi.advanceTimersByTime(100);
+      const result = await resultPromise;
+      expect(result).toEqual({ answer: "Quick!", wasFreeform: true });
+    });
+
+    it("defaults timeoutMs to 120000", async () => {
+      const inner = vi
+        .fn<(req: UserInputRequest) => Promise<UserInputResponse>>()
+        .mockImplementation(() => new Promise(() => {}));
+
+      const handler = createTimeoutUserInputHandler({ handler: inner });
+      const resultPromise = handler({ question: "Long wait?" });
+
+      // Should NOT have timed out yet at 119s
+      vi.advanceTimersByTime(119_000);
+      // Use a microtask check — the promise should still be pending
+      let resolved = false;
+      void resultPromise.then(() => {
+        resolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resolved).toBe(false);
+
+      // Now advance past 120s
+      vi.advanceTimersByTime(1_000);
+      const result = await resultPromise;
+      expect(result).toEqual({ answer: "No response", wasFreeform: true });
+    });
+  });
+});

--- a/src/agents/copilot-user-input.ts
+++ b/src/agents/copilot-user-input.ts
@@ -1,0 +1,49 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/copilot-user-input");
+
+export type UserInputRequest = {
+  question: string;
+  choices?: string[];
+  allowFreeform?: boolean;
+};
+
+export type UserInputResponse = {
+  answer: string;
+  wasFreeform: boolean;
+};
+
+export type UserInputHandlerFn = (request: UserInputRequest) => Promise<UserInputResponse>;
+
+export type TimeoutUserInputHandlerOptions = {
+  handler: UserInputHandlerFn;
+  timeoutMs?: number;
+  defaultAnswer?: string;
+};
+
+/**
+ * Wraps a user input handler with timeout logic.
+ * If the inner handler doesn't resolve within `timeoutMs`, returns a fallback response.
+ */
+export function createTimeoutUserInputHandler(
+  options: TimeoutUserInputHandlerOptions,
+): UserInputHandlerFn {
+  const { handler, timeoutMs = 120_000, defaultAnswer } = options;
+  const fallbackAnswer = defaultAnswer ?? "No response";
+
+  return async (request: UserInputRequest): Promise<UserInputResponse> => {
+    const result = await Promise.race([
+      handler(request),
+      new Promise<UserInputResponse>((resolve) => {
+        setTimeout(() => {
+          log.warn("user input handler timed out", {
+            timeoutMs,
+            questionLength: request.question.length,
+          });
+          resolve({ answer: fallbackAnswer, wasFreeform: true });
+        }, timeoutMs);
+      }),
+    ]);
+    return result;
+  };
+}


### PR DESCRIPTION
Enables the SDK's `ask_user` tool via `onUserInputRequest`. New `copilot-user-input.ts` with timeout-wrapped handler. Placeholder auto-response for now — real messaging surface integration in a future PR. 8 tests. Part of #4