### PR TITLE
feat(agents): map OpenClaw think levels to Copilot SDK reasoning effort

### DIFF
--- a/src/agents/copilot-reasoning.test.ts
+++ b/src/agents/copilot-reasoning.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
+import {
+  mapThinkLevelToReasoningEffort,
+  validateReasoningEffort,
+  type ReasoningModelInfo,
+} from "./copilot-reasoning.js";
+
+describe("mapThinkLevelToReasoningEffort", () => {
+  const cases: [ThinkLevel | undefined, string | undefined][] = [
+    ["off", undefined],
+    ["minimal", undefined],
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "high"],
+    ["xhigh", "xhigh"],
+    ["adaptive", undefined],
+    [undefined, undefined],
+  ];
+
+  it.each(cases)("maps %s → %s", (input, expected) => {
+    expect(mapThinkLevelToReasoningEffort(input)).toBe(expected);
+  });
+});
+
+describe("validateReasoningEffort", () => {
+  it("returns undefined when effort is undefined", () => {
+    expect(validateReasoningEffort(undefined, {} as ReasoningModelInfo)).toBeUndefined();
+  });
+
+  it("returns undefined when model doesn't support reasoning", () => {
+    expect(validateReasoningEffort("high", { capabilities: { supports: {} } })).toBeUndefined();
+  });
+
+  it("returns undefined when modelInfo is undefined", () => {
+    expect(validateReasoningEffort("high", undefined)).toBeUndefined();
+  });
+
+  it("returns the effort when model supports it", () => {
+    const model: ReasoningModelInfo = {
+      capabilities: { supports: { reasoningEffort: true } },
+      supportedReasoningEfforts: ["low", "medium", "high"],
+      defaultReasoningEffort: "medium",
+    };
+    expect(validateReasoningEffort("high", model)).toBe("high");
+  });
+
+  it("falls back to model default when effort not in supported list", () => {
+    const model: ReasoningModelInfo = {
+      capabilities: { supports: { reasoningEffort: true } },
+      supportedReasoningEfforts: ["low", "medium"],
+      defaultReasoningEffort: "medium",
+    };
+    expect(validateReasoningEffort("xhigh", model)).toBe("medium");
+  });
+
+  it("returns effort when no supportedReasoningEfforts list", () => {
+    const model: ReasoningModelInfo = {
+      capabilities: { supports: { reasoningEffort: true } },
+    };
+    expect(validateReasoningEffort("high", model)).toBe("high");
+  });
+
+  it("returns undefined when unsupported and no default", () => {
+    const model: ReasoningModelInfo = {
+      capabilities: { supports: { reasoningEffort: true } },
+      supportedReasoningEfforts: ["low"],
+    };
+    expect(validateReasoningEffort("xhigh", model)).toBeUndefined();
+  });
+});

--- a/src/agents/copilot-reasoning.ts
+++ b/src/agents/copilot-reasoning.ts
@@ -1,0 +1,60 @@
+/**
+ * Maps OpenClaw ThinkLevel to the Copilot SDK's ReasoningEffort.
+ */
+import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
+
+/** SDK reasoning effort levels. */
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+/** Model info subset needed for validation. */
+export interface ReasoningModelInfo {
+  capabilities?: { supports?: { reasoningEffort?: boolean } };
+  supportedReasoningEfforts?: ReasoningEffort[];
+  defaultReasoningEffort?: ReasoningEffort;
+}
+
+/**
+ * Convert an OpenClaw ThinkLevel to a Copilot SDK ReasoningEffort.
+ * Returns undefined when reasoning should not be explicitly set.
+ */
+export function mapThinkLevelToReasoningEffort(
+  thinkLevel: ThinkLevel | undefined,
+): ReasoningEffort | undefined {
+  switch (thinkLevel) {
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "xhigh";
+    // "off", "minimal", "adaptive", undefined → don't set
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Validate that the model supports the requested reasoning effort.
+ * Falls back to the model's default if the level isn't supported,
+ * or undefined if the model doesn't support reasoning at all.
+ */
+export function validateReasoningEffort(
+  effort: ReasoningEffort | undefined,
+  modelInfo: ReasoningModelInfo | undefined,
+): ReasoningEffort | undefined {
+  if (!effort) {
+    return undefined;
+  }
+  if (!modelInfo?.capabilities?.supports?.reasoningEffort) {
+    return undefined;
+  }
+
+  const supported = modelInfo.supportedReasoningEfforts;
+  if (supported && !supported.includes(effort)) {
+    return modelInfo.defaultReasoningEffort ?? undefined;
+  }
+
+  return effort;
+}

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -6,6 +6,7 @@ import { resolveSessionAgentIds } from "./agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
+import { mapThinkLevelToReasoningEffort } from "./copilot-reasoning.js";
 import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
@@ -121,6 +122,7 @@ export async function runCopilotCliAgent(params: {
       systemPrompt,
       timeoutMs: params.timeoutMs,
       sessionId: params.cliSessionId,
+      reasoningEffort: mapThinkLevelToReasoningEffort(params.thinkLevel),
     });
 
     const text = result.text?.trim();

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -116,6 +116,7 @@ export type CopilotAgentRunOptions = {
   systemPrompt?: string;
   timeoutMs?: number;
   sessionId?: string;
+  reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 };
 
 export type CopilotAgentRunResult = {
@@ -139,8 +140,13 @@ export async function runCopilotAgent(
   try {
     await ensureAuthenticated(client);
 
+    if (options.reasoningEffort) {
+      log.info(`copilot-sdk: reasoningEffort=${options.reasoningEffort}`);
+    }
+
     const sessionConfig: SessionConfig = {
       model: options.model,
+      reasoningEffort: options.reasoningEffort,
       workingDirectory: options.workspaceDir,
       streaming: true,
       // Deny tool-use permission requests by default (security: callers must


### PR DESCRIPTION
New `copilot-reasoning.ts` maps ThinkLevel → ReasoningEffort with model capability validation. Converts off/minimal/adaptive → undefined, direct passthrough for low/medium/high/xhigh. 15 tests. Part of #4